### PR TITLE
Add minimal audit inspection depth and use in repo commands

### DIFF
--- a/cmd/cli/repos/protocol.go
+++ b/cmd/cli/repos/protocol.go
@@ -14,21 +14,21 @@ import (
 )
 
 const (
-	protocolUseConstant          = "repo-protocol-convert [root ...]"
-	protocolShortDescription     = "Convert repository origin remotes between protocols"
-	protocolLongDescription      = "repo-protocol-convert updates origin remotes to use the requested Git protocol."
-	protocolDryRunFlagName       = "dry-run"
-	protocolDryRunDescription    = "Preview protocol conversions without making changes"
-	protocolAssumeYesFlagName    = "yes"
-	protocolAssumeYesShorthand   = "y"
-	protocolAssumeYesDescription = "Automatically confirm protocol conversions"
-	protocolFromFlagName         = "from"
-	protocolFromDescription      = "Current protocol to convert from (git|ssh|https)"
-	protocolToFlagName           = "to"
-	protocolToDescription        = "Protocol to convert to (git|ssh|https)"
-	protocolErrorMissingPair     = "specify both --from and --to"
-	protocolErrorSamePair        = "--from and --to cannot be the same protocol"
-	protocolErrorInvalidValue    = "unsupported protocol value: %s"
+	protocolUseConstant            = "repo-protocol-convert [root ...]"
+	protocolShortDescription       = "Convert repository origin URLs between git/ssh/https"
+	protocolLongDescription        = "repo-protocol-convert converts origin URLs to a desired protocol."
+	protocolDryRunFlagName         = "dry-run"
+	protocolDryRunFlagDescription  = "Preview protocol conversions without making changes"
+	protocolAssumeYesFlagName      = "yes"
+	protocolAssumeYesFlagShorthand = "y"
+	protocolAssumeYesDescription   = "Automatically confirm protocol conversions"
+	protocolFromFlagName           = "from"
+	protocolFromFlagDescription    = "Current protocol to convert from (git, ssh, https)"
+	protocolToFlagName             = "to"
+	protocolToFlagDescription      = "Target protocol to convert to (git, ssh, https)"
+	protocolErrorMissingPair       = "specify both --from and --to"
+	protocolErrorSamePair          = "--from and --to must differ"
+	protocolErrorInvalidValue      = "invalid protocol value: %s"
 )
 
 // ProtocolCommandBuilder assembles the repo-protocol-convert command.
@@ -52,10 +52,10 @@ func (builder *ProtocolCommandBuilder) Build() (*cobra.Command, error) {
 		RunE:  builder.run,
 	}
 
-	command.Flags().Bool(protocolDryRunFlagName, false, protocolDryRunDescription)
-	command.Flags().BoolP(protocolAssumeYesFlagName, protocolAssumeYesShorthand, false, protocolAssumeYesDescription)
-	command.Flags().String(protocolFromFlagName, "", protocolFromDescription)
-	command.Flags().String(protocolToFlagName, "", protocolToDescription)
+	command.Flags().Bool(protocolDryRunFlagName, false, protocolDryRunFlagDescription)
+	command.Flags().BoolP(protocolAssumeYesFlagName, protocolAssumeYesFlagShorthand, false, protocolAssumeYesDescription)
+	command.Flags().String(protocolFromFlagName, "", protocolFromFlagDescription)
+	command.Flags().String(protocolToFlagName, "", protocolToFlagDescription)
 
 	return command, nil
 }
@@ -134,7 +134,7 @@ func (builder *ProtocolCommandBuilder) run(command *cobra.Command, arguments []s
 
 	service := audit.NewService(repositoryDiscoverer, gitManager, gitExecutor, githubResolver, command.OutOrStdout(), command.ErrOrStderr())
 
-	inspections, inspectionError := service.DiscoverInspections(command.Context(), roots, false)
+	inspections, inspectionError := service.DiscoverInspections(command.Context(), roots, false, audit.InspectionDepthMinimal)
 	if inspectionError != nil {
 		return inspectionError
 	}

--- a/cmd/cli/repos/protocol_test.go
+++ b/cmd/cli/repos/protocol_test.go
@@ -168,7 +168,7 @@ func TestProtocolCommandConfigurationPrecedence(testInstance *testing.T) {
 		testInstance.Run(testCase.name, func(subtest *testing.T) {
 			discoverer := &fakeRepositoryDiscoverer{repositories: []string{remotesDiscoveredRepository}}
 			executor := &fakeGitExecutor{}
-			manager := &fakeGitRepositoryManager{remoteURL: testCase.initialRemoteURL, currentBranch: remotesMetadataDefaultBranch}
+			manager := &fakeGitRepositoryManager{remoteURL: testCase.initialRemoteURL, currentBranch: remotesMetadataDefaultBranch, panicOnCurrentBranchLookup: true}
 			resolver := &fakeGitHubResolver{metadata: githubcli.RepositoryMetadata{NameWithOwner: remotesCanonicalRepository, DefaultBranch: remotesMetadataDefaultBranch}}
 			prompter := &recordingPrompter{confirmResult: true}
 

--- a/cmd/cli/repos/remotes.go
+++ b/cmd/cli/repos/remotes.go
@@ -92,7 +92,7 @@ func (builder *RemotesCommandBuilder) run(command *cobra.Command, arguments []st
 
 	service := audit.NewService(repositoryDiscoverer, gitManager, gitExecutor, githubResolver, command.OutOrStdout(), command.ErrOrStderr())
 
-	inspections, inspectionError := service.DiscoverInspections(command.Context(), roots, false)
+	inspections, inspectionError := service.DiscoverInspections(command.Context(), roots, false, audit.InspectionDepthMinimal)
 	if inspectionError != nil {
 		return inspectionError
 	}

--- a/cmd/cli/repos/remotes_test.go
+++ b/cmd/cli/repos/remotes_test.go
@@ -134,7 +134,7 @@ func TestRemotesCommandConfigurationPrecedence(testInstance *testing.T) {
 		testInstance.Run(testCase.name, func(subtest *testing.T) {
 			discoverer := &fakeRepositoryDiscoverer{repositories: []string{remotesDiscoveredRepository}}
 			executor := &fakeGitExecutor{}
-			manager := &fakeGitRepositoryManager{remoteURL: remotesOriginURLConstant, currentBranch: remotesMetadataDefaultBranch}
+			manager := &fakeGitRepositoryManager{remoteURL: remotesOriginURLConstant, currentBranch: remotesMetadataDefaultBranch, panicOnCurrentBranchLookup: true}
 			resolver := &fakeGitHubResolver{metadata: githubcli.RepositoryMetadata{NameWithOwner: remotesCanonicalRepository, DefaultBranch: remotesMetadataDefaultBranch}}
 			prompter := &recordingPrompter{confirmResult: true}
 

--- a/cmd/cli/repos/rename.go
+++ b/cmd/cli/repos/rename.go
@@ -103,7 +103,7 @@ func (builder *RenameCommandBuilder) run(command *cobra.Command, arguments []str
 
 	service := audit.NewService(repositoryDiscoverer, gitManager, gitExecutor, githubResolver, command.OutOrStdout(), command.ErrOrStderr())
 
-	inspections, inspectionError := service.DiscoverInspections(command.Context(), roots, false)
+	inspections, inspectionError := service.DiscoverInspections(command.Context(), roots, false, audit.InspectionDepthMinimal)
 	if inspectionError != nil {
 		return inspectionError
 	}

--- a/cmd/cli/repos/test_helpers_test.go
+++ b/cmd/cli/repos/test_helpers_test.go
@@ -36,12 +36,13 @@ type remoteUpdateCall struct {
 }
 
 type fakeGitRepositoryManager struct {
-	remoteURL        string
-	currentBranch    string
-	setCalls         []remoteUpdateCall
-	cleanWorktree    bool
-	cleanWorktreeSet bool
-	checkCleanCalls  int
+	remoteURL                  string
+	currentBranch              string
+	setCalls                   []remoteUpdateCall
+	cleanWorktree              bool
+	cleanWorktreeSet           bool
+	checkCleanCalls            int
+	panicOnCurrentBranchLookup bool
 }
 
 func (manager *fakeGitRepositoryManager) CheckCleanWorktree(context.Context, string) (bool, error) {
@@ -53,6 +54,9 @@ func (manager *fakeGitRepositoryManager) CheckCleanWorktree(context.Context, str
 }
 
 func (manager *fakeGitRepositoryManager) GetCurrentBranch(context.Context, string) (string, error) {
+	if manager.panicOnCurrentBranchLookup {
+		panic("GetCurrentBranch should not be called during minimal inspection")
+	}
 	return manager.currentBranch, nil
 }
 

--- a/internal/audit/command.go
+++ b/internal/audit/command.go
@@ -90,8 +90,9 @@ func (builder *CommandBuilder) parseOptions(command *cobra.Command) (CommandOpti
 	}
 
 	options := CommandOptions{
-		Roots:       roots,
-		DebugOutput: debugMode,
+		Roots:           roots,
+		DebugOutput:     debugMode,
+		InspectionDepth: InspectionDepthFull,
 	}
 
 	return options, nil

--- a/internal/audit/service.go
+++ b/internal/audit/service.go
@@ -43,7 +43,7 @@ func (service *Service) Run(executionContext context.Context, options CommandOpt
 		return errors.New(missingRootsErrorMessageConstant)
 	}
 
-	inspections, inspectionError := service.DiscoverInspections(executionContext, roots, options.DebugOutput)
+	inspections, inspectionError := service.DiscoverInspections(executionContext, roots, options.DebugOutput, options.InspectionDepth)
 	if inspectionError != nil {
 		return inspectionError
 	}
@@ -52,7 +52,9 @@ func (service *Service) Run(executionContext context.Context, options CommandOpt
 }
 
 // DiscoverInspections collects repository inspections for the provided roots.
-func (service *Service) DiscoverInspections(executionContext context.Context, roots []string, debug bool) ([]RepositoryInspection, error) {
+func (service *Service) DiscoverInspections(executionContext context.Context, roots []string, debug bool, inspectionDepth InspectionDepth) ([]RepositoryInspection, error) {
+	normalizedDepth := normalizeInspectionDepth(inspectionDepth)
+
 	repositories, discoveryError := service.discoverer.DiscoverRepositories(roots)
 	if discoveryError != nil {
 		return nil, discoveryError
@@ -74,7 +76,7 @@ func (service *Service) DiscoverInspections(executionContext context.Context, ro
 			continue
 		}
 
-		inspection, inspectError := service.inspectRepository(executionContext, repositoryPath)
+		inspection, inspectError := service.inspectRepository(executionContext, repositoryPath, normalizedDepth)
 		if inspectError != nil {
 			continue
 		}
@@ -130,6 +132,15 @@ func deduplicatePaths(paths []string) []string {
 	return unique
 }
 
+func normalizeInspectionDepth(depth InspectionDepth) InspectionDepth {
+	switch depth {
+	case InspectionDepthMinimal:
+		return InspectionDepthMinimal
+	default:
+		return InspectionDepthFull
+	}
+}
+
 func (service *Service) isGitRepository(executionContext context.Context, repositoryPath string) bool {
 	commandDetails := execshell.CommandDetails{
 		Arguments:        []string{gitRevParseSubcommandConstant, gitIsInsideWorkTreeFlagConstant},
@@ -144,7 +155,7 @@ func (service *Service) isGitRepository(executionContext context.Context, reposi
 	return strings.TrimSpace(executionResult.StandardOutput) == gitTrueOutputConstant
 }
 
-func (service *Service) inspectRepository(executionContext context.Context, repositoryPath string) (RepositoryInspection, error) {
+func (service *Service) inspectRepository(executionContext context.Context, repositoryPath string, inspectionDepth InspectionDepth) (RepositoryInspection, error) {
 	folderName := filepath.Base(repositoryPath)
 
 	originURL, originError := service.gitManager.GetRemoteURL(executionContext, repositoryPath, shared.OriginRemoteNameConstant)
@@ -175,13 +186,16 @@ func (service *Service) inspectRepository(executionContext context.Context, repo
 		remoteDefaultBranch = service.resolveDefaultBranchFromGit(executionContext, repositoryPath)
 	}
 
-	localBranch, localBranchError := service.gitManager.GetCurrentBranch(executionContext, repositoryPath)
-	if localBranchError != nil {
-		localBranch = ""
+	localBranch := ""
+	inSyncStatus := TernaryValueNotApplicable
+	if inspectionDepth == InspectionDepthFull {
+		branchName, localBranchError := service.gitManager.GetCurrentBranch(executionContext, repositoryPath)
+		if localBranchError == nil {
+			sanitizedBranch := sanitizeBranchName(branchName)
+			localBranch = sanitizedBranch
+			inSyncStatus = service.computeInSync(executionContext, repositoryPath, remoteDefaultBranch, sanitizedBranch, remoteProtocol)
+		}
 	}
-	localBranch = sanitizeBranchName(localBranch)
-
-	inSync := service.computeInSync(executionContext, repositoryPath, remoteDefaultBranch, localBranch, remoteProtocol)
 
 	finalOwnerRepo := originOwnerRepo
 	if len(strings.TrimSpace(canonicalOwnerRepo)) > 0 {
@@ -199,7 +213,7 @@ func (service *Service) inspectRepository(executionContext context.Context, repo
 		RemoteProtocol:         remoteProtocol,
 		RemoteDefaultBranch:    remoteDefaultBranch,
 		LocalBranch:            localBranch,
-		InSyncStatus:           inSync,
+		InSyncStatus:           inSyncStatus,
 		OriginMatchesCanonical: matchesCanonical(originOwnerRepo, canonicalOwnerRepo),
 	}
 	return inspection, nil

--- a/internal/audit/types.go
+++ b/internal/audit/types.go
@@ -23,10 +23,20 @@ const (
 	TernaryValueNotApplicable TernaryValue = "n/a"
 )
 
+// InspectionDepth determines how much repository state should be gathered.
+type InspectionDepth string
+
+// Supported inspection depth variants.
+const (
+	InspectionDepthFull    InspectionDepth = "full"
+	InspectionDepthMinimal InspectionDepth = "minimal"
+)
+
 // CommandOptions captures the configurable parameters for the audit command.
 type CommandOptions struct {
-	Roots       []string
-	DebugOutput bool
+	Roots           []string
+	DebugOutput     bool
+	InspectionDepth InspectionDepth
 }
 
 // RepositoryInspection captures gathered repository state.

--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -74,7 +74,7 @@ func (executor *Executor) Execute(executionContext context.Context, roots []stri
 		executor.dependencies.Errors,
 	)
 
-	inspections, inspectionError := auditService.DiscoverInspections(executionContext, sanitizedRoots, false)
+	inspections, inspectionError := auditService.DiscoverInspections(executionContext, sanitizedRoots, false, audit.InspectionDepthFull)
 	if inspectionError != nil {
 		return fmt.Errorf(workflowRepositoryLoadErrorTemplate, inspectionError)
 	}

--- a/internal/workflow/state.go
+++ b/internal/workflow/state.go
@@ -30,7 +30,7 @@ func (state *RepositoryState) Refresh(executionContext context.Context, service 
 		return errors.New(repositoryRefreshMissingServiceMessageConstant)
 	}
 
-	inspections, inspectionError := service.DiscoverInspections(executionContext, []string{state.Path}, false)
+	inspections, inspectionError := service.DiscoverInspections(executionContext, []string{state.Path}, false, audit.InspectionDepthFull)
 	if inspectionError != nil {
 		return inspectionError
 	}


### PR DESCRIPTION
## Summary
- add an inspection depth option to the audit service and default command options
- request minimal repository inspections for remotes, protocol, and rename commands while keeping workflow actions on full inspections
- expand unit test doubles and scenarios to cover both full and minimal inspection flows

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68daff27fea88327a51fe794d40135d5