### PR TITLE
Switch CLI initialization banner to console format

### DIFF
--- a/cmd/cli/application_test.go
+++ b/cmd/cli/application_test.go
@@ -2,7 +2,9 @@ package cli_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,34 +21,41 @@ import (
 	"github.com/temirov/gix/internal/branches"
 	"github.com/temirov/gix/internal/migrate"
 	"github.com/temirov/gix/internal/packages"
+	"github.com/temirov/gix/internal/utils"
 )
 
 const (
-	testConfigurationFileNameConstant             = "config.yaml"
-	testConfigurationHeaderConstant               = "common:\n  log_level: info\n  log_format: structured\noperations:\n"
-	testOperationBlockTemplateConstant            = "  - operation: %s\n    with:\n%s"
-	testOperationRootsTemplateConstant            = "      roots:\n        - %s\n"
-	testOperationRootDirectoryConstant            = "/tmp/config-root"
-	testConfigurationSearchPathEnvironmentName    = "GIX_CONFIG_SEARCH_PATH"
-	testPackagesCommandNameConstant               = "repo-packages-purge"
-	testBranchMigrateCommandNameConstant          = "branch-migrate"
-	testBranchCleanupCommandNameConstant          = "repo-prs-purge"
-	testReposRemotesCommandNameConstant           = "repo-remote-update"
-	testReposProtocolCommandNameConstant          = "repo-protocol-convert"
-	testReposRenameCommandNameConstant            = "repo-folders-rename"
-	testAuditCommandNameConstant                  = "audit"
-	testWorkflowCommandNameConstant               = "workflow"
-	embeddedDefaultsBranchCleanupTestNameConstant = "BranchCleanupDefaults"
-	embeddedDefaultsPackagesTestNameConstant      = "PackagesDefaults"
-	embeddedDefaultsReposRemotesTestNameConstant  = "ReposRemotesDefaults"
-	embeddedDefaultsReposProtocolTestNameConstant = "ReposProtocolDefaults"
-	embeddedDefaultsReposRenameTestNameConstant   = "ReposRenameDefaults"
-	embeddedDefaultsWorkflowTestNameConstant      = "WorkflowDefaults"
-	embeddedDefaultsBranchMigrateTestNameConstant = "BranchMigrateDefaults"
-	embeddedDefaultsAuditTestNameConstant         = "AuditDefaults"
-	embeddedDefaultRootPathConstant               = "."
-	embeddedDefaultRemoteNameConstant             = "origin"
-	embeddedDefaultPullRequestLimitConstant       = 100
+	testConfigurationFileNameConstant               = "config.yaml"
+	testConfigurationHeaderConstant                 = "common:\n  log_level: info\n  log_format: structured\noperations:\n"
+	testConsoleConfigurationHeaderConstant          = "common:\n  log_level: info\n  log_format: console\noperations:\n"
+	testOperationBlockTemplateConstant              = "  - operation: %s\n    with:\n%s"
+	testOperationRootsTemplateConstant              = "      roots:\n        - %s\n"
+	testOperationRootDirectoryConstant              = "/tmp/config-root"
+	testConfigurationSearchPathEnvironmentName      = "GIX_CONFIG_SEARCH_PATH"
+	testPackagesCommandNameConstant                 = "repo-packages-purge"
+	testBranchMigrateCommandNameConstant            = "branch-migrate"
+	testBranchCleanupCommandNameConstant            = "repo-prs-purge"
+	testReposRemotesCommandNameConstant             = "repo-remote-update"
+	testReposProtocolCommandNameConstant            = "repo-protocol-convert"
+	testReposRenameCommandNameConstant              = "repo-folders-rename"
+	testAuditCommandNameConstant                    = "audit"
+	testWorkflowCommandNameConstant                 = "workflow"
+	embeddedDefaultsBranchCleanupTestNameConstant   = "BranchCleanupDefaults"
+	embeddedDefaultsPackagesTestNameConstant        = "PackagesDefaults"
+	embeddedDefaultsReposRemotesTestNameConstant    = "ReposRemotesDefaults"
+	embeddedDefaultsReposProtocolTestNameConstant   = "ReposProtocolDefaults"
+	embeddedDefaultsReposRenameTestNameConstant     = "ReposRenameDefaults"
+	embeddedDefaultsWorkflowTestNameConstant        = "WorkflowDefaults"
+	embeddedDefaultsBranchMigrateTestNameConstant   = "BranchMigrateDefaults"
+	embeddedDefaultsAuditTestNameConstant           = "AuditDefaults"
+	embeddedDefaultRootPathConstant                 = "."
+	embeddedDefaultRemoteNameConstant               = "origin"
+	embeddedDefaultPullRequestLimitConstant         = 100
+	configurationInitializedMessageTextConstant     = "configuration initialized"
+	configurationInitializedConsoleTemplateConstant = "%s | log level=%s | log format=%s | config file=%s"
+	configurationLogLevelFieldNameConstant          = "log_level"
+	configurationLogFormatFieldNameConstant         = "log_format"
+	configurationFileFieldNameConstant              = "config_file"
 )
 
 var requiredOperationNames = []string{
@@ -132,6 +141,91 @@ func TestApplicationInitializeConfiguration(t *testing.T) {
 			default:
 				t.Fatalf("unexpected error sample type %T", testCase.expectedErrorSample)
 			}
+		})
+	}
+}
+
+func TestApplicationInitializationLoggingModes(testInstance *testing.T) {
+	testCases := []struct {
+		name                string
+		configurationHeader string
+		assertion           func(*testing.T, string, string)
+	}{
+		{
+			name:                "StructuredLogging",
+			configurationHeader: testConfigurationHeaderConstant,
+			assertion: func(t *testing.T, capturedOutput string, configurationPath string) {
+				t.Helper()
+
+				trimmedOutput := strings.TrimSpace(capturedOutput)
+				require.NotEmpty(t, trimmedOutput)
+
+				logLines := strings.Split(trimmedOutput, "\n")
+				require.Len(t, logLines, 1)
+
+				var logEntry map[string]any
+				require.NoError(t, json.Unmarshal([]byte(logLines[0]), &logEntry))
+
+				messageValue, messageValueExists := logEntry["msg"].(string)
+				require.True(t, messageValueExists)
+				require.Equal(t, configurationInitializedMessageTextConstant, messageValue)
+
+				logLevelValue, logLevelExists := logEntry[configurationLogLevelFieldNameConstant].(string)
+				require.True(t, logLevelExists)
+				require.Equal(t, string(utils.LogLevelInfo), logLevelValue)
+
+				logFormatValue, logFormatExists := logEntry[configurationLogFormatFieldNameConstant].(string)
+				require.True(t, logFormatExists)
+				require.Equal(t, string(utils.LogFormatStructured), logFormatValue)
+
+				configurationFileValue, configurationFileExists := logEntry[configurationFileFieldNameConstant].(string)
+				require.True(t, configurationFileExists)
+				require.Equal(t, configurationPath, configurationFileValue)
+			},
+		},
+		{
+			name:                "ConsoleLogging",
+			configurationHeader: testConsoleConfigurationHeaderConstant,
+			assertion: func(t *testing.T, capturedOutput string, configurationPath string) {
+				t.Helper()
+
+				trimmedOutput := strings.TrimSpace(capturedOutput)
+				require.NotEmpty(t, trimmedOutput)
+
+				expectedBanner := fmt.Sprintf(
+					configurationInitializedConsoleTemplateConstant,
+					configurationInitializedMessageTextConstant,
+					string(utils.LogLevelInfo),
+					string(utils.LogFormatConsole),
+					configurationPath,
+				)
+
+				require.Contains(t, trimmedOutput, expectedBanner)
+				require.NotContains(t, trimmedOutput, "\""+configurationLogLevelFieldNameConstant+"\"")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		testInstance.Run(testCase.name, func(t *testing.T) {
+			configurationDirectory := t.TempDir()
+			configurationContent := buildConfigurationContentWithHeader(testCase.configurationHeader, requiredOperationNames)
+			configurationPath := filepath.Join(configurationDirectory, testConfigurationFileNameConstant)
+
+			writeConfigurationFile(t, configurationPath, configurationContent)
+
+			t.Setenv(testConfigurationSearchPathEnvironmentName, configurationDirectory)
+
+			application := cli.NewApplication()
+
+			stderrCapture := startTestStderrCapture(t)
+			initializationError := application.InitializeForCommand(testPackagesCommandNameConstant)
+			capturedOutput := stderrCapture.Stop(t)
+
+			require.NoError(t, initializationError)
+
+			testCase.assertion(t, capturedOutput, configurationPath)
 		})
 	}
 }
@@ -287,8 +381,12 @@ func TestApplicationEmbeddedDefaultsProvideCommandConfigurations(testInstance *t
 }
 
 func buildConfigurationContent(operationNames []string) string {
+	return buildConfigurationContentWithHeader(testConfigurationHeaderConstant, operationNames)
+}
+
+func buildConfigurationContentWithHeader(commonHeader string, operationNames []string) string {
 	configurationBuilder := strings.Builder{}
-	configurationBuilder.WriteString(testConfigurationHeaderConstant)
+	configurationBuilder.WriteString(commonHeader)
 
 	for _, operationName := range operationNames {
 		rootsBlock := fmt.Sprintf(testOperationRootsTemplateConstant, testOperationRootDirectoryConstant)
@@ -354,4 +452,42 @@ func decodeOperationOptions(testingInstance testing.TB, options map[string]any, 
 
 	decodeError := decoder.Decode(options)
 	require.NoError(testingInstance, decodeError)
+}
+
+type testStderrCapture struct {
+	originalDescriptor *os.File
+	reader             *os.File
+	writer             *os.File
+}
+
+func startTestStderrCapture(testingInstance testing.TB) testStderrCapture {
+	testingInstance.Helper()
+
+	reader, writer, pipeError := os.Pipe()
+	require.NoError(testingInstance, pipeError)
+
+	capture := testStderrCapture{
+		originalDescriptor: os.Stderr,
+		reader:             reader,
+		writer:             writer,
+	}
+
+	os.Stderr = writer
+
+	return capture
+}
+
+func (capture *testStderrCapture) Stop(testingInstance testing.TB) string {
+	testingInstance.Helper()
+
+	os.Stderr = capture.originalDescriptor
+
+	require.NoError(testingInstance, capture.writer.Close())
+
+	capturedBytes, readError := io.ReadAll(capture.reader)
+	require.NoError(testingInstance, readError)
+
+	require.NoError(testingInstance, capture.reader.Close())
+
+	return string(capturedBytes)
 }


### PR DESCRIPTION
## Summary
- emit the CLI initialization banner through the console logger when human-readable logging is selected while keeping structured logging unchanged
- retain the structured logger for structured mode and ensure both diagnostic and console loggers are flushed
- extend application tests to capture stderr output, asserting the console banner text and verifying the structured logger output remains unchanged

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68db0650106c83279f5195c45da2bdf3